### PR TITLE
Private documentation flag for sphinx

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Sphinx build
         run: |
           cd docs
-          sphinx-apidoc -o . ../dicom_utils -f
+          sphinx-apidoc -P -o . ../dicom_utils -f
           make html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
dicom_utils code is in __init__.py: this requires
the "-P" flag for the functions to be parsed by
sphinx-apidoc